### PR TITLE
LtePhyBase: fall back to lteRadioIn gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ cleanall: checkmakefiles
 	@rm -f src/Makefile
 
 makefiles:
-	@cd src && opp_makemake --make-so -f --deep -o lte -O out -KINET_PROJ=../../inet -DINET_IMPORT -I. -I$$\(INET_PROJ\)/src -L$$\(INET_PROJ\)/out/$$\(CONFIGNAME\)/src -lINET
+	@cd src && opp_makemake --make-so -f --deep -o lte -O out -KINET_PROJ=../../inet -DINET_IMPORT -I. -I$$\(INET_PROJ\)/src -L$$\(INET_PROJ\)/out/$$\(CONFIGNAME\)/src -lINET$$\(D\)
 
 checkmakefiles:
 	@if [ ! -f src/Makefile ]; then \

--- a/src/stack/mac/layer/LteMacEnb.cc
+++ b/src/stack/mac/layer/LteMacEnb.cc
@@ -272,7 +272,7 @@ void LteMacEnb::initialize(int stage)
         binder_->addEnbInfo(info);
 
         // register the pair <id,name> to the binder
-        const char* moduleName = getParentModule()->getParentModule()->getName();
+        const char* moduleName = getParentModule()->getParentModule()->getFullName();
         binder_->registerName(nodeId_, moduleName);
     }
 }

--- a/src/stack/phy/layer/LtePhyBase.cc
+++ b/src/stack/phy/layer/LtePhyBase.cc
@@ -295,7 +295,14 @@ void LtePhyBase::sendUnicast(LteAirFrame *frame)
     // get a pointer to receiving module
     cModule *receiver = getSimulation()->getModule(destOmnetId);
     // receiver's gate
-    sendDirect(frame, 0, frame->getDuration(), receiver, "radioIn");
+    int gateIdx = receiver->findGate("radioIn");
+    if (gateIdx < 0) {
+        gateIdx = receiver->findGate("lteRadioIn");
+        if (gateIdx < 0) {
+            throw cRuntimeError("receiver \"%s\" has no suitable radio gate", receiver->getFullPath().c_str());
+        }
+    }
+    sendDirect(frame, 0, frame->getDuration(), receiver, gateIdx);
 
     return;
 }


### PR DESCRIPTION
If a network host fulfills INET's INetworkNode module interface this host cannot be equipped with a LTE NIC because of clashing gate names. INetworkNode has a gate vector 'radioIn' whereas SimuLTE requires a scalar gate of the same name.
This workaround enables 'lteRadioIn' as fallback name, i.e. if no scalar 'radioIn' gate is found it tries 'lteRadioIn' next. Of course, this not a particularly nice solution...