### PR TITLE
LteRlcUm: fix deletion of Tx and Rx entities

### DIFF
--- a/src/stack/rlc/um/LteRlcUm.cc
+++ b/src/stack/rlc/um/LteRlcUm.cc
@@ -213,8 +213,8 @@ void LteRlcUm::deleteQueues(MacNodeId nodeId)
     {
         if (nodeType == UE || (nodeType == ENODEB && MacCidToNodeId(tit->first) == nodeId))
         {
-            delete tit->second;        // Delete Entity
-            txEntities_.erase(tit++);    // Delete Elem
+            tit->second->deleteModule();        // Delete Entity
+            tit = txEntities_.erase(tit);    // Delete Elem
         }
         else
         {
@@ -225,8 +225,8 @@ void LteRlcUm::deleteQueues(MacNodeId nodeId)
     {
         if (nodeType == UE || (nodeType == ENODEB && MacCidToNodeId(rit->first) == nodeId))
         {
-            delete rit->second;        // Delete Entity
-            rxEntities_.erase(rit++);    // Delete Elem
+            rit->second->deleteModule();        // Delete Entity
+            rit = rxEntities_.erase(rit);    // Delete Elem
         }
         else
         {


### PR DESCRIPTION
OMNeT++ 5.6.1 throws a runtime error when modules are deleted by plain `delete` instead of `deleteModule` calls.