### PR TITLE
apps: add path prefixes to #include of generated message headers

### DIFF
--- a/src/apps/burst/BurstReceiver.h
+++ b/src/apps/burst/BurstReceiver.h
@@ -8,7 +8,7 @@
 #include "inet/transportlayer/contract/udp/UDPSocket.h"
 #include "inet/networklayer/common/L3AddressResolver.h"
 
-#include "BurstPacket_m.h"
+#include "apps/burst/BurstPacket_m.h"
 
 using namespace inet;
 

--- a/src/apps/burst/BurstSender.h
+++ b/src/apps/burst/BurstSender.h
@@ -11,7 +11,7 @@
 #include "inet/transportlayer/contract/udp/UDPSocket.h"
 #include "inet/networklayer/common/L3AddressResolver.h"
 
-#include "BurstPacket_m.h"
+#include "apps/burst/BurstPacket_m.h"
 
 using namespace inet;
 

--- a/src/apps/cbr/CbrReceiver.h
+++ b/src/apps/cbr/CbrReceiver.h
@@ -8,7 +8,7 @@
 #include "inet/transportlayer/contract/udp/UDPSocket.h"
 #include "inet/networklayer/common/L3AddressResolver.h"
 
-#include "CbrPacket_m.h"
+#include "apps/cbr/CbrPacket_m.h"
 
 using namespace inet;
 

--- a/src/apps/cbr/CbrSender.h
+++ b/src/apps/cbr/CbrSender.h
@@ -11,7 +11,7 @@
 #include "inet/transportlayer/contract/udp/UDPSocket.h"
 #include "inet/networklayer/common/L3AddressResolver.h"
 
-#include "CbrPacket_m.h"
+#include "apps/cbr/CbrPacket_m.h"
 
 using namespace inet;
 


### PR DESCRIPTION
Most #includes already have a complete path prefix.
These few remaining places prevented out-of-tree builds.