### PR TITLE
Dynamic association compared to RSSI 0dB (1mW) on init and will not select any eNB

### DIFF
--- a/src/stack/phy/layer/LtePhyUe.cc
+++ b/src/stack/phy/layer/LtePhyUe.cc
@@ -41,7 +41,7 @@ void LtePhyUe::initialize(int stage)
         handoverLatency_ = par("handoverLatency").doubleValue();
         dynamicCellAssociation_ = par("dynamicCellAssociation");
         currentMasterRssi_ = 0;
-        candidateMasterRssi_ = 0;
+        candidateMasterRssi_ = -120.0; // set do MIN_VALUE to allow best eNB selection during dynamic association
         hysteresisTh_ = 0;
         hysteresisFactor_ = 10;
         handoverDelta_ = 0.00001;
@@ -127,7 +127,8 @@ void LtePhyUe::initialize(int stage)
                     rssi += *it;
                 rssi /= rssiV.size();   // compute the mean over all RBs
 
-                EV << "LtePhyUe::initialize - RSSI from eNodeB " << cellId << ": " << rssi << " dB (current candidate eNodeB " << candidateMasterId_ << ": " << candidateMasterRssi_ << " dB" << endl;
+                EV << "LtePhyUe::initialize - RSSI from eNodeB " << cellId << ": " << rssi << " dB (current candidate eNodeB "
+                        << candidateMasterId_ << ": " << candidateMasterRssi_ << " dB" << endl;
 
                 if (rssi > candidateMasterRssi_)
                 {
@@ -218,7 +219,8 @@ void LtePhyUe::handoverHandler(LteAirFrame* frame, UserControlInfo* lteInfo)
         rssi /= rssiV.size();
     }
 
-    EV << "UE " << nodeId_ << " broadcast frame from " << lteInfo->getSourceId() << " with RSSI: " << rssi << " at " << simTime() << endl;
+    EV << "UE " << nodeId_ << " broadcast frame from " << lteInfo->getSourceId()
+            << " with RSSI: " << rssi << " at " << simTime() << endl;
 
     if (rssi > candidateMasterRssi_ + hysteresisTh_)
     {


### PR DESCRIPTION
The `candidateMasterRssi_` is initialized to `0` during initialization [line 44][1]. If 
dynamicCellAssociation is [true][2]  the calculated RSSI is compared [here][3] to the initial 
value of `0dBm` which is never reached, thus no association takes place. Initializing candiatemasterRssi_ with e.g. `-120dB`
will select the 'best' eNB during association, even if communication is not possible 
because of bad RSSI value.



[1]: https://github.com/inet-framework/simulte/blob/master/src/stack/phy/layer/LtePhyUe.cc#L44
[2]: https://github.com/inet-framework/simulte/blob/master/src/stack/phy/layer/LtePhyUe.cc#L100
[3]: https://github.com/inet-framework/simulte/blob/master/src/stack/phy/layer/LtePhyUe.cc#L132
