### PR TITLE
Empty buffer for cid XX while expected SDUs were YY  runtime error in multiple D2D application usecase

### DIFF
--- a/src/stack/mac/layer/LteMacUe.cc
+++ b/src/stack/mac/layer/LteMacUe.cc
@@ -176,7 +176,6 @@ int LteMacUe::macSduRequest()
         allocatedBytes.push_back(schedulingGrant_->getGrantedCwBytes(cw));
 
     LteMacScheduleList* scheduledBytesList = lcgScheduler_->getScheduledBytesList();
-    bool firstSdu = true;
 
     // Ask for a MAC sdu for each scheduled user on each codeword
     LteMacScheduleList::const_iterator it;
@@ -190,10 +189,9 @@ int LteMacUe::macSduRequest()
         LteMacScheduleList::const_iterator bit = scheduledBytesList->find(key);
 
         unsigned int sduSize = bit->second;
-        if (firstSdu)
+        if (lcgScheduler_->isFirstSdu(destCid))
         {
             sduSize -= MAC_HEADER;    // do not consider MAC header size
-            firstSdu = false;
         }
 
         // consume bytes on this codeword

--- a/src/stack/mac/scheduler/LcgScheduler.h
+++ b/src/stack/mac/scheduler/LcgScheduler.h
@@ -73,6 +73,8 @@ class SIMULTE_API LcgScheduler
     // scheduled bytes list
     ScheduleList scheduledBytesList_;
 
+    MacCid firstSduCid;
+
     /// Cid List
     typedef std::list<MacCid> CidList;
 
@@ -110,6 +112,10 @@ class SIMULTE_API LcgScheduler
      * scheduled for each connection
      */
     virtual ScheduleList& getScheduledBytesList();
+
+    inline virtual bool isFirstSdu(const MacCid& cid){
+        return firstSduCid == cid;
+    }
 
     // *****************************************************************************************
 

--- a/src/stack/mac/scheduler/LteSchedulerUeUl.cc
+++ b/src/stack/mac/scheduler/LteSchedulerUeUl.cc
@@ -111,3 +111,7 @@ LteMacScheduleList* LteSchedulerUeUl::getScheduledBytesList()
 {
     return &scheduledBytesList_;
 }
+
+bool LteSchedulerUeUl::isFirstSdu(const MacCid& cid){
+    return lcgScheduler_->isFirstSdu(cid);
+}

--- a/src/stack/mac/scheduler/LteSchedulerUeUl.h
+++ b/src/stack/mac/scheduler/LteSchedulerUeUl.h
@@ -47,6 +47,8 @@ class SIMULTE_API LteSchedulerUeUl
      */
     LteMacScheduleList* getScheduledBytesList();
 
+    bool isFirstSdu(const MacCid& cid);
+
     /*
      * constructor
      */


### PR DESCRIPTION
In one of my simulations I encountered a problem where the above mentioned exception is 
triggered [here][5] about 30 minutes into my simulation. Setup:

* Coupled simulation with Sumo over TraCI
* Multiple eNBs (6)
* 120 nodes (Pedestrians, manged by Sumo)
* Each pedestrian has 3 D2D applications sending broadcast messages (link local)
* `*.lteNic.phy.dynamicCellAssociation = true`
* `**.lteNic.phy.enableHandover = true`

The node in question is created out of range of any eNB and thus cannot transmit.
This also needs PR #64 to work. During this time the applications create messages
which will be queued in the RLC Layer, each within a dedicated connection. 

In the Mac layer the MacBuffers accepts the `LteRlcPduNewData` as expected. When the 
node enters TX/RX range with a eNB scheduling grants are received and the Mac layer 
starts the scheduling ([LcgScheduler][6]) as expected. Due to the full Buffers only one 
of the connections is scheduled leading to scheduleList that looks something like this:

```
cid         numSDUs
73990145      0
73990146      0
73990147      1
```

All `availableBytes` are given to a single connection id. Note that the
`availableBytes` must include the `MAC_HEADER` (once) and the
`RLC_HEADER` (for each cid). After scheduling the Mac layer calls
[LteMacUe::macSduRequest()][1] to create `LteMacSduRequests` for each
connection currently available. This includes _all_ connection even if the did
not receive any available bytes. In line [183][2] the scheduleList is iterated,
creating the `LteMacSduRequests` as mentioned. From the first Sdu the scheduled
number of bytes is reduced by the MAC_HEADER [(here)][3]. However, in my case
the first item in the iterator didn't get allocated any bytes, leading to a
negative number of bytes for this SDU. This does not create an error because
the sduSize is of the type unsigned int (underflow) and the RLC layer code will
cast it to and int later on and ignores the request [(see here)][4].

This however means that for `cid 73990147` 2 Bytes more are requested than actually
needed. This will lead to difference between the RLC Buffer length and the
MacBuffer length which should be synchronized.  The RLC Buffer will run out of
data but the MacBuffer still has data which will be scheduled but no data will
be send down from the RLC layer, leading to the mentions exception.  This error
will only occur if multiple connections exist, only one of them is served and
if the iterators in `LteMacUe::macSduRequest()` and in the `LcgScheduler` have
different order allowing an empty `LteMacSduRequest` to be the first SDU. 

To reproduce the error create a breakpoint [here][3] with an condition of
`sduSize <= 0`. In this case the MAC_HEADER is not removed correctly and for
some other connection to many bytes are requested from the RLC layer leading to
an offset between the RLC and LteMacBuffer.

In the pull request I fixed the issue by directly specifying which connection
provides the first SDU so the MAC_HEADER is removed from the correct
connection. Another approach would be to give the scheduler the correct amount
of `availabeBytes` where the MAC_HEADER is already removed. However I am not
sure if this breaks something else I am not aware of. 



[1]: https://github.com/inet-framework/simulte/blob/master/src/stack/mac/layer/LteMacUe.cc#L168
[2]: https://github.com/inet-framework/simulte/blob/master/src/stack/mac/layer/LteMacUe.cc#L183
[3]: https://github.com/inet-framework/simulte/blob/master/src/stack/mac/layer/LteMacUe.cc#L195
[4]: https://github.com/inet-framework/simulte/blob/master/src/stack/rlc/um/entity/UmTxEntity.cc#L69
[5]: https://github.com/inet-framework/simulte/blob/master/src/stack/mac/layer/LteMacUe.cc#L387
[6]: https://github.com/inet-framework/simulte/blob/master/src/stack/mac/scheduler/LcgScheduler.cc
